### PR TITLE
Fix deprecated string interpolation style.

### DIFF
--- a/src/Checks/Database.php
+++ b/src/Checks/Database.php
@@ -29,12 +29,12 @@ class Database extends PreflightCheck
         $attributes = [];
 
         foreach (['CLIENT_VERSION', 'CONNECTION_STATUS', 'SERVER_INFO', 'SERVER_VERSION'] as $attribute) {
-            $attributes[$attribute] = $pdo->getAttribute(constant("PDO::ATTR_${attribute}"));
+            $attributes[$attribute] = $pdo->getAttribute(constant("PDO::ATTR_{$attribute}"));
         }
 
         $connection = $this->getConnection();
 
-        return $result->pass("Connected to DB (Connection: ${connection})", $attributes);
+        return $result->pass("Connected to DB (Connection: {$connection})", $attributes);
     }
 
     /**
@@ -46,11 +46,11 @@ class Database extends PreflightCheck
         $this->requiredConfig = array_merge(
             $this->requiredConfig,
             [
-                "database.connections.${connection}.host",
-                "database.connections.${connection}.port",
-                "database.connections.${connection}.database",
-                "database.connections.${connection}.username",
-                "database.connections.${connection}.password",
+                "database.connections.{$connection}.host",
+                "database.connections.{$connection}.port",
+                "database.connections.{$connection}.database",
+                "database.connections.{$connection}.username",
+                "database.connections.{$connection}.password",
             ]
         );
     }

--- a/src/Checks/Redis.php
+++ b/src/Checks/Redis.php
@@ -56,11 +56,11 @@ class Redis extends PreflightCheck
         $this->requiredConfig = array_merge(
             $this->requiredConfig,
             [
-                "database.redis.${connection}.host",
-                "database.redis.${connection}.port",
+                "database.redis.{$connection}.host",
+                "database.redis.{$connection}.port",
             ],
             $usesAuth ? [
-                "database.redis.${connection}.password",
+                "database.redis.{$connection}.password",
             ] : []
         );
     }


### PR DESCRIPTION
Removes use of string interpolation style deprecated in PHP 8.2.

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated#dollar-outside

---

We are seeing a number of similar errors in our logs:

> PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /srv/api/vendor/kirschbaum-development/laravel-preflight-checks/src/Checks/Database.php on line 32