### PR TITLE
Add PHP 8.3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: run-tests
 
-on: [push]
+on: push
 
 jobs:
   tests:
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
         laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
         exclude:
           - php: 7.4
@@ -28,7 +28,13 @@ jobs:
             laravel: 7.*
           - php: 8.2
             laravel: 8.*
-          - php: 8.2
+          - php: 8.3
+            laravel: 6.*
+          - php: 8.3
+            laravel: 7.*
+          - php: 8.3
+            laravel: 8.*
+          - php: 8.3
             laravel: 9.*
         include:
           - laravel: 10.*


### PR DESCRIPTION
Update the build matrix : 
- Add PHP 8.3 for Laravel 10
- PHP 8.2 was disabled for Laravel 9, but it is supported, so I re-enabled it

Ref : https://laravel.com/docs/10.x/releases#support-policy