### PR TITLE
Properly handle boolean config values set to `false`

### DIFF
--- a/src/Checks/PreflightCheck.php
+++ b/src/Checks/PreflightCheck.php
@@ -123,7 +123,7 @@ abstract class PreflightCheck
         $missingKeys = [];
 
         foreach ($this->requiredConfig as $configKey) {
-            if (! config()->has($configKey) || empty(config($configKey))) {
+            if (! config()->has($configKey) || ! is_bool(config($configKey)) && empty(config($configKey))) {
                 $missingKeys[] = $configKey;
             }
         }

--- a/src/Checks/PreflightCheck.php
+++ b/src/Checks/PreflightCheck.php
@@ -123,7 +123,9 @@ abstract class PreflightCheck
         $missingKeys = [];
 
         foreach ($this->requiredConfig as $configKey) {
-            if (! config()->has($configKey) || ! is_bool(config($configKey)) && empty(config($configKey))) {
+            $configValue = config($configKey);
+
+            if (! config()->has($configKey) || ! is_bool($configValue) && empty($configValue)) {
                 $missingKeys[] = $configKey;
             }
         }

--- a/src/Checks/PreflightCheck.php
+++ b/src/Checks/PreflightCheck.php
@@ -125,7 +125,7 @@ abstract class PreflightCheck
         foreach ($this->requiredConfig as $configKey) {
             $configValue = config($configKey);
 
-            if (! config()->has($configKey) || ! is_bool($configValue) && empty($configValue)) {
+            if (! is_bool($configValue) && empty($configValue)) {
                 $missingKeys[] = $configKey;
             }
         }

--- a/tests/Checks/ConfigurationTest.php
+++ b/tests/Checks/ConfigurationTest.php
@@ -30,6 +30,19 @@ class ConfigurationTest extends BasePreflightCheckTest
     /**
      * @test
      */
+    public function testPassesWhenConfigIsBooleanAndSetToFalse()
+    {
+        $config = ['test1' => false];
+        config($config);
+        $preflightCheck = new Configuration(array_keys($config));
+
+        $result = $preflightCheck->check(new Result('Test\Test'));
+        $this->assertPassed($result);
+    }
+
+    /**
+     * @test
+     */
     public function testFailsWhenConfigIsNotSet()
     {
         $config = ['test1', 'test2'];


### PR DESCRIPTION
- Updates Configuration check to properly handle boolean config values set to false -- this specific case never passes the preflight check because although the config value is present, because `empty(false)` returns `true`.